### PR TITLE
CMake Fix for Github breakage (#1332)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -70,6 +70,13 @@ jobs:
           ZeroRhythm]
 
     steps:
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: '3.16.x'
+    - name: Verify cmake
+      run: cmake --version
+   
     #Global Setup
     - name: Checkout GP2040-CE
       uses: actions/checkout@v4.1.1


### PR DESCRIPTION
Update to our github actions to downgrade Cmake version to 3.16.x